### PR TITLE
Add Lit Ipsum

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 * [Fillerati](http://www.fillerati.com/) - Pulls full text from Project Gutenburg. `HTML` `Polysource`
 * [Harry Potter Ipsum](http://www.christinachern.com/hpipsum/) - Accio Filler Text!
 * [Joyce Ipsum](http://joyceipsum.com/ulysses/) - Featuring James Joyce's "Ulysses".
+* [Lit Ipsum](https://litipsum.com/) - Classic literature ipsum with texts from Project Gutenberg. Click and drag to copy to clipboard. Responsive. `AJAX` `API` `HTML` `Polysource`
 * [Lorem Gibson](http://loremgibson.com/) - Featuring the works of William Gibson.
 * [Schmipsum](http://www.schmipsum.com/) - Featuring a variety of interesting literary and historical sources. `Polysource` `API`
 


### PR DESCRIPTION
Hi Sam, I've made Lit Ipsum, a literary lipsum to replace Fillerati, which I used all the time till it went dark a few months ago. This kind of ipsum is useful because it provides real sentences. It serves up public-domain texts from Gutenberg.org. It's responsive, and the UI enables you to click and select text in one easy move. It has a cross-origin accessible API, with options for p and li tags and JSON. [https://litipsum.com](https://litipsum.com)

Thanks!
Andfinally