### PR TITLE
Remove dead link - Duck Island Greeking Machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 * [Bullshit Ipsum](http://bullshitipsum.com/) - Marketing-flavored buzzwords and phrases. Free of swear words despite the name.
 * [Corporate Ipsum](http://www.cipsum.com/) - Designed to facilitate the needs of corporate paper-pushers everywhere.
 * [Dad Ipsum](http://dadipsum.com/) - Just because I do it does not mean you can.
-* [Duck Island Greeking Machine](http://duckisland.com/GreekMachine.php) - Choose from 9 completely unrelated sources. `Polysource`
 * [Hairy Lipsum](http://hairylipsum.com/) - Is your Latin lacking a certain rugged handsomeness?
 * [Ipsum Generator](http://ipsum.ecxol.net/) - Offers option to pepper original lorem ipsum with different flavoring. `lang-French` `Polysource`
 * [Lorem Fucking Ipsum](http://loremfuckingipsum.com/) - Placeholder text for people who have some fucking passion!


### PR DESCRIPTION
Dead link for "Duck Island Greeking Machine" is removed. Solution for issue #17.

Great resource by the way...