### PR TITLE
Ramen ipsum is no longer available on heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Cupcake Ipsum](http://www.cupcakeipsum.com/) - The sweetest ipsum.
 - [Liquor Ipsum](http://liquoripsum.com/) - A stiffer lorem ipsum generator.
 - [Pizza Ipsum](https://pizzaipsum.com) - Ipsum hot from the oven.
-- [Ramen Ipsum](https://ramenipsum.herokuapp.com) - A brothier Lorem Ipsum generator. `API` `GitHub` `lang-Japanese` `lang-Thai`
+- [Ramen Ipsum](https://github.com/kelvintaywl/ramenipsum) - A brothier Lorem Ipsum generator. `GitHub` `lang-Japanese` `lang-Thai`
 - [Tuna Ipsum](http://tunaipsum.com) - A Fishier Lorem Ipsum Generator.
 - [Wine Ipsum](https://www.wineipsum.com/) - In vino veritas.
 


### PR DESCRIPTION
There's a lot of other dead links, but I was looking at ramen ipsum, and noticed it has github source, so I figured the link might as well at least point to the source.

Also removed the "API" tag since there is not an API up and ready to use